### PR TITLE
Fixed German "Umlauts" and missing navbar entry

### DIFF
--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -16,7 +16,7 @@ true=Wahr
 false=Falsch
 unknown=Unbekannt
 save=Speichern
-close=Schließen
+close=SchlieÃŸen
 
 #############
 # HOME-PAGE #
@@ -70,57 +70,61 @@ home.removePassword.desc=Den Passwortschutz eines PDFs entfernen.
 home.compressPdfs.title=PDF komprimieren
 home.compressPdfs.desc=PDF komprimieren um die DateigrÃ¶ÃŸe zu reduzieren.
 
-home.changeMetadata.title=Metadaten ändern
-home.changeMetadata.desc=Ändern/Entfernen/Hinzufügen von Metadaten aus einem PDF-Dokument
+home.changeMetadata.title=Metadaten Ã¤ndern
+home.changeMetadata.desc=Ã„ndern/Entfernen/HinzufÃ¼gen von Metadaten aus einem PDF-Dokument
 
 home.fileToPDF.title=Datei in PDF konvertieren
 home.fileToPDF.desc=Konvertieren Sie nahezu jede Datei in PDF (DOCX, PNG, XLS, PPT, TXT und mehr)
 
-home.ocr.title=Führe OCR auf PDF- und/oder Cleanup-Scans aus
-home.ocr.desc=Cleanup scannt und erkennt Text aus Bildern in einer PDF-Datei und fügt ihn erneut als Text hinzu.
+home.ocr.title=FÃ¼hre OCR auf PDF- und/oder Cleanup-Scans aus
+home.ocr.desc=Cleanup scannt und erkennt Text aus Bildern in einer PDF-Datei und fÃ¼gt ihn erneut als Text hinzu.
 
 home.extractImages.title=Bilder extrahieren
 home.extractImages.desc=Extrahiert alle Bilder aus einer PDF-Datei und speichert sie als Zip-Datei
 
+home.pdfToPDFA.title=PDF zu PDF/A konvertieren
+home.pdfToPDFA.desc=PDF zu PDF/A fÃ¼r Langzeitarchivierung konvertieren
+
+
 navbar.settings=Einstellungen
 settings.title=Einstellungen
-settings.update=Update verfügbar
+settings.update=Update verfÃ¼gbar
 settings.appVersion=App-Version:
-settings.downloadOption.title=Download-Option wählen (für einzelne Dateien, die keine Zip-Downloads sind):
-settings.downloadOption.1=Im selben Fenster öffnen
-settings.downloadOption.2=In neuem Fenster öffnen
+settings.downloadOption.title=Download-Option wÃ¤hlen (fÃ¼r einzelne Dateien, die keine Zip-Downloads sind):
+settings.downloadOption.1=Im selben Fenster Ã¶ffnen
+settings.downloadOption.2=In neuem Fenster Ã¶ffnen
 settings.downloadOption.3=Datei herunterladen
-settings.zipThreshold=Dateien komprimieren, wenn die Anzahl der heruntergeladenen Dateien überschritten wird
+settings.zipThreshold=Dateien komprimieren, wenn die Anzahl der heruntergeladenen Dateien Ã¼berschritten wird
 
 #OCR
 ocr.title=OCR / Scan-Bereinigung
 ocr.header=Scans bereinigen / OCR (Optical Character Recognition)
-ocr.selectText.1=Sprachen auswählen, die im PDF erkannt werden sollen (die aufgelisteten sind die aktuell erkannten):
-ocr.selectText.2=Textdatei erzeugen, die OCR-Text neben dem OCR-bearbeiteten PDF enthält
+ocr.selectText.1=Sprachen auswÃ¤hlen, die im PDF erkannt werden sollen (die aufgelisteten sind die aktuell erkannten):
+ocr.selectText.2=Textdatei erzeugen, die OCR-Text neben dem OCR-bearbeiteten PDF enthÃ¤lt
 ocr.selectText.3=Korrekte Seiten wurden in einem schiefen Winkel gescannt, indem sie wieder an ihren Platz gedreht wurden
-ocr.selectText.4=Seite säubern, daher ist es weniger wahrscheinlich, dass OCR Text im Hintergrundrauschen findet. (Keine Ausgangsänderung)
-ocr.selectText.5=Seite säubern, sodass es weniger wahrscheinlich ist, dass OCR Text im Hintergrundrauschen findet, Bereinigung der Ausgabe wird beibehalten.
+ocr.selectText.4=Seite sÃ¤ubern, daher ist es weniger wahrscheinlich, dass OCR Text im Hintergrundrauschen findet. (Keine AusgangsÃ¤nderung)
+ocr.selectText.5=Seite sÃ¤ubern, sodass es weniger wahrscheinlich ist, dass OCR Text im Hintergrundrauschen findet, Bereinigung der Ausgabe wird beibehalten.
 ocr.selectText.6=Ignoriert Seiten mit interaktivem Text, nur OCR-Seiten, die Bilder sind
-ocr.selectText.7=OCR erzwingen, OCR wird jede Seite entfernen und alle ursprünglichen Textelemente entfernen
-ocr.selectText.8=Normal (Fehler, wenn PDF Text enthält)
-ocr.selectText.9=Zusätzliche Einstellungen
+ocr.selectText.7=OCR erzwingen, OCR wird jede Seite entfernen und alle ursprÃ¼nglichen Textelemente entfernen
+ocr.selectText.8=Normal (Fehler, wenn PDF Text enthÃ¤lt)
+ocr.selectText.9=ZusÃ¤tzliche Einstellungen
 ocr.selectText.10=OCR-Modus
-ocr.help=Bitte lesen Sie diese Dokumentation, um zu erfahren, wie Sie dies für andere Sprachen verwenden und/oder nicht in Docker verwenden können
-ocr.credit=Dieser Dienst verwendet OCRmyPDF und Tesseract für OCR.
+ocr.help=Bitte lesen Sie diese Dokumentation, um zu erfahren, wie Sie dies fÃ¼r andere Sprachen verwenden und/oder nicht in Docker verwenden kÃ¶nnen
+ocr.credit=Dieser Dienst verwendet OCRmyPDF und Tesseract fÃ¼r OCR.
 ocr.submit=PDF mit OCR verarbeiten
 
 
 extractImages.title=Bilder extrahieren
 extractImages.header=Bilder extrahieren
-extractImages.selectText=Wählen Sie das Bildformat aus, in das extrahierte Bilder konvertiert werden sollen
+extractImages.selectText=WÃ¤hlen Sie das Bildformat aus, in das extrahierte Bilder konvertiert werden sollen
 extractImages.submit=Extrahieren
 
 
 #File to PDF
 fileToPDF.title=Datei in PDF
 fileToPDF.header=Beliebige Dateien in PDF konvertieren
-fileToPDF.credit=Dieser Dienst verwendet LibreOffice und Unoconv für die Dateikonvertierung.
-fileToPDF.supportedFileTypes=Unterstützte Dateitypen sollten die folgenden enthalten, eine vollständige aktualisierte Liste der unterstützten Formate finden Sie jedoch in der LibreOffice-Dokumentation
+fileToPDF.credit=Dieser Dienst verwendet LibreOffice und Unoconv fÃ¼r die Dateikonvertierung.
+fileToPDF.supportedFileTypes=UnterstÃ¼tzte Dateitypen sollten die folgenden enthalten, eine vollstÃ¤ndige aktualisierte Liste der unterstÃ¼tzten Formate finden Sie jedoch in der LibreOffice-Dokumentation
 fileToPDF.submit=In PDF konvertieren
 
 
@@ -135,7 +139,7 @@ addImage.submit=Bild hinzufÃ¼gen
 #compress
 compress.title=Komprimieren
 compress.header=PDF komprimieren
-compress.credit=Dieser Dienst verwendet OCRmyPDF für die PDF-Komprimierung/-Optimierung.
+compress.credit=Dieser Dienst verwendet OCRmyPDF fÃ¼r die PDF-Komprimierung/-Optimierung.
 compress.selectText.1=Optimierungsstufe:
 compress.selectText.2=0 (Keine Optimierung)
 compress.selectText.3=1 (Standard, verlustfreie Optimierung)
@@ -194,7 +198,7 @@ imageToPDF.submit=Umwandeln
 imageToPDF.selectText.1=Auf Seite strecken
 imageToPDF.selectText.2=PDF automatisch drehen
 imageToPDF.selectText.3=Mehrere Dateien verarbeiten (nur aktiv, wenn Sie mit mehreren Bildern arbeiten)
-imageToPDF.selectText.4=In ein einziges PDF zusammenführen
+imageToPDF.selectText.4=In ein einziges PDF zusammenfÃ¼hren
 imageToPDF.selectText.5=In separate PDFs konvertieren
 
 #pdfToImage
@@ -202,12 +206,12 @@ pdfToImage.title=PDF zu Bild
 pdfToImage.header=PDF zu Bild
 pdfToImage.selectText=Bildformat
 pdfToImage.singleOrMultiple=Bildergebnistyp
-pdfToImage.single=Einzelnes großes Bild
+pdfToImage.single=Einzelnes groÃŸes Bild
 pdfToImage.multi=Mehrere Bilder
 pdfToImage.colorType=Farbtyp
 pdfToImage.color=Farbe
 pdfToImage.grey=Graustufen
-pdfToImage.blackwhite=Schwarzweiß (Datenverlust möglich!)
+pdfToImage.blackwhite=SchwarzweiÃŸ (Datenverlust mÃ¶glich!)
 pdfToImage.submit=Umwandeln
 
 #addPassword
@@ -243,7 +247,7 @@ watermark.submit=Wasserzeichen hinzufÃ¼gen
 #remove-watermark
 remove-watermark.title=Wasserzeichen entfernen
 remove-watermark.header=Wasserzeichen entfernen
-remove-watermark.selectText.1=PDF auswählen, um Wasserzeichen zu entfernen von:
+remove-watermark.selectText.1=PDF auswÃ¤hlen, um Wasserzeichen zu entfernen von:
 remove-watermark.selectText.2=Wasserzeichentext:
 remove-watermark.submit=Wasserzeichen entfernen
 
@@ -271,35 +275,35 @@ removePassword.selectText.2=Passwort
 removePassword.submit=Entfernen
 
 
-changeMetadata.title=Metadaten ändern
-changeMetadata.header=Metadaten ändern
-changeMetadata.selectText.1=Bitte bearbeiten Sie die Variablen, die Sie ändern möchten
-changeMetadata.selectText.2=Alle Metadaten löschen
+changeMetadata.title=Metadaten Ã¤ndern
+changeMetadata.header=Metadaten Ã¤ndern
+changeMetadata.selectText.1=Bitte bearbeiten Sie die Variablen, die Sie Ã¤ndern mÃ¶chten
+changeMetadata.selectText.2=Alle Metadaten lÃ¶schen
 changeMetadata.selectText.3=Benutzerdefinierte Metadaten anzeigen:
 changeMetadata.author=Autor:
 changeMetadata.creationDate=Erstellungsdatum (jjjj/MM/tt HH:mm:ss):
 changeMetadata.creator=Ersteller:
-changeMetadata.keywords=Schlüsselwörter:
-changeMetadata.modDate=Änderungsdatum (JJJJ/MM/TT HH:mm:ss):
+changeMetadata.keywords=SchlÃ¼sselwÃ¶rter:
+changeMetadata.modDate=Ã„nderungsdatum (JJJJ/MM/TT HH:mm:ss):
 changeMetadata.producer=Produzent:
 changeMetadata.subject=Betreff:
 changeMetadata.title=Titel:
 changeMetadata.trapped=Gefangen:
 changeMetadata.selectText.4=Andere Metadaten:
-changeMetadata.selectText.5=Benutzerdefinierten Metadateneintrag hinzufügen
-changeMetadata.submit=Ändern
+changeMetadata.selectText.5=Benutzerdefinierten Metadateneintrag hinzufÃ¼gen
+changeMetadata.submit=Ã„ndern
 
 
 
 xlsToPdf.title=Excel in PDF
 xlsToPdf.header=Excel in PDF
-xlsToPdf.selectText.1=XLS- oder XLSX-Excel-Tabelle zum Konvertieren auswählen
+xlsToPdf.selectText.1=XLS- oder XLSX-Excel-Tabelle zum Konvertieren auswÃ¤hlen
 xlsToPdf.convert=konvertieren
 
 
 pdfToPDFA.title=PDF zu PDF/A
 pdfToPDFA.header=PDF zu PDF/A
-pdfToPDFA.credit=Dieser Dienst verwendet OCRmyPDF für die PDF/A-Konvertierung
+pdfToPDFA.credit=Dieser Dienst verwendet OCRmyPDF fÃ¼r die PDF/A-Konvertierung
 pdfToPDFA.submit=Konvertieren
 
 


### PR DESCRIPTION
This might fix the encoding errors with the German "Umlaute" and adds the missing navbar entry translation for `home.pdfToPDFA.*`.