### PR TITLE
Fix title in add-page-numbers.html

### DIFF
--- a/src/main/resources/templates/other/add-page-numbers.html
+++ b/src/main/resources/templates/other/add-page-numbers.html
@@ -4,7 +4,7 @@
 	xmlns:th="http://www.thymeleaf.org">
 
 <th:block
-	th:insert="~{fragments/common :: head(title=#{autoCrop.title})}"></th:block>
+	th:insert="~{fragments/common :: head(title=#{addPageNumbers.title})}"></th:block>
 
 
 <body>


### PR DESCRIPTION
The key `autoCrop.title` was used instead of `addPageNumbers.title`.