### PR TITLE
Update messages_fr_FR.properties

### DIFF
--- a/src/main/resources/messages_fr_FR.properties
+++ b/src/main/resources/messages_fr_FR.properties
@@ -1,16 +1,16 @@
 ###########
 # Generic #
 ###########
-# the direction that the language is written (ltr=left to right, rtl = right to left)
+# the direction that the language is written (ltr = left to right, rtl = right to left)
 language.direction=ltr
 
-pdfPrompt=Choisir PDF
-multiPdfPrompt=Choisir des PDF (2+)
+pdfPrompt=Sélectionnez le(s) PDF
+multiPdfPrompt=Sélectionnez les PDF
 multiPdfDropPrompt=Sélectionnez (ou glissez-déposez) tous les PDF dont vous avez besoin
 imgPrompt=Choisir une image
 genericSubmit=Soumettre
-processTimeWarning=Attention�: ce processus peut prendre jusqu'à une minute en fonction de la taille du fichier
-pageOrderPrompt=Ordre des pages (Entrez une liste de numéros de page séparés par des virgules):
+processTimeWarning=Attention, ce processus peut prendre jusqu\u2019à une minute en fonction de la taille du fichier.
+pageOrderPrompt=Ordre des pages (entrez une liste de numéros de page séparés par des virgules ou des fonctions telles que 2n+1)\u00a0:
 goToPage=Aller
 true=Vrai
 false=Faux
@@ -19,18 +19,18 @@ save=Enregistrer
 close=Fermer
 filesSelected=fichiers sélectionnés
 noFavourites=Aucun favori ajouté
-bored=Ennuyé d'attendre ?
+bored=Ennuyé d\u2019attendre\u00a0?
 alphabet=Alphabet
 downloadPdf=Télécharger le PDF
 text=Texte
 font=Police
-selectFillter=-- Select --
+selectFillter=-- Sélectionnez --
 pageNum=numéro de page
-sizes.small=Small
-sizes.medium=Medium
-sizes.large=Large
-sizes.x-large=X-Large
-error.pdfPassword=The PDF Document is passworded and either the password was not provided or was incorrect
+sizes.small=Petit
+sizes.medium=Moyen
+sizes.large=Grand
+sizes.x-large=Très grand
+error.pdfPassword=Le document PDF est protégé par un mot de passe et le mot de passe n\u2019a pas été fourni ou était incorrect
 
 
 #############
@@ -40,7 +40,7 @@ navbar.convert=Convertir
 navbar.security=Sécurité
 navbar.other=Autre
 navbar.darkmode=Mode sombre
-navbar.pageOps=Opérations de page
+navbar.pageOps=Opérations sur les pages
 navbar.settings=Paramètres
 
 #############
@@ -48,220 +48,217 @@ navbar.settings=Paramètres
 #############
 settings.title=Paramètres
 settings.update=Mise à jour disponible
-settings.appVersion=Version de l'application :
-settings.downloadOption.title=Choisissez l'option de téléchargement (pour les téléchargements sans fichier unique) :
+settings.appVersion=Version de l\u2019application\u00a0:
+settings.downloadOption.title=Choisissez l\u2019option de téléchargement (pour les téléchargements à fichier unique non ZIP)\u00a0:
 settings.downloadOption.1=Ouvrir dans la même fenêtre
 settings.downloadOption.2=Ouvrir dans une nouvelle fenêtre
-settings.downloadOption.3=Fichier téléchargé
-settings.zipThreshold=Zip les fichiers lorsque le nombre de fichiers téléchargés dépasse
+settings.downloadOption.3=Télécharger le fichier
+settings.zipThreshold=Compresser les fichiers en ZIP lorsque le nombre de fichiers téléchargés dépasse
 
 #############
 # HOME-PAGE #
 #############
-home.desc=Votre guichet unique hébergé localement pour tous vos besoins PDF.
+home.desc=Votre application Web hébergée localement pour répondre à tous vos besoins PDF.
 
 
-home.multiTool.title=Multi-outil PDF
-home.multiTool.desc=Fusionner, faire pivoter, réorganiser et supprimer des pages
-multiTool.tags=Multi Tool,Multi operation,UI,click drag,front end,client side
+home.multiTool.title=Outil multifonction PDF
+home.multiTool.desc=Fusionnez, faites pivoter, réorganisez et supprimez des pages.
+multiTool.tags=outil multifonction,opération multifonction,interface utilisateur,glisser déposer,front-end,client side,interactif,intransigeant,déplacer,multi tool
 
-home.merge.title=Fusionnez
+home.merge.title=Fusionner
 home.merge.desc=Fusionnez facilement plusieurs PDF en un seul.
-merge.tags=merge,Page operations,Back end,server side
+merge.tags=fusionner,opérations sur les pages,backeend,server side,merge
 
-home.split.title=Fractionner
-home.split.desc=Diviser les PDF en plusieurs documents
-split.tags=Page operations,divide,Multi Page,cut,server side
+home.split.title=Diviser
+home.split.desc=Divisez un PDF en plusieurs documents.
+split.tags=opérations sur les pages,diviser,plusieurs pages,cut,server side,divide
 
-home.rotate.title=Tourner
+home.rotate.title=Pivoter
 home.rotate.desc=Faites pivoter facilement vos PDF.
-rotate.tags=server side
+rotate.tags=pivoter,server side,rotate
 
 
-home.imageToPdf.title=Image au format PDF
-home.imageToPdf.desc=Convertir une image (PNG, JPEG, GIF) en PDF.
-imageToPdf.tags=conversion,img,jpg,picture,photo
+home.imageToPdf.title=Image en PDF
+home.imageToPdf.desc=Convertissez une image (PNG, JPEG, GIF) en PDF.
+imageToPdf.tags=pdf,conversion,img,jpg,image,photo
 
-home.pdfToImage.title=PDF vers image
-home.pdfToImage.desc=Convertir un PDF en image. (PNG, JPEG, GIF)
-pdfToImage.tags=conversion,img,jpg,picture,photo
+home.pdfToImage.title=PDF en image
+home.pdfToImage.desc=Convertissez un PDF en image (PNG, JPEG, GIF).
+pdfToImage.tags=conversion,img,jpg,image,photo
 
-home.pdfOrganiser.title=Organisateur
-home.pdfOrganiser.desc=Supprimer/Réorganiser les pages dans n'importe quel ordre
-pdfOrganiser.tags=duplex,even,odd,sort,move
+home.pdfOrganiser.title=Organiser
+home.pdfOrganiser.desc=Supprimez ou réorganisez les pages dans n\u2019importe quel ordre.
+pdfOrganiser.tags=organiser,recto-verso,duplex,even,odd,sort,move
 
 
-home.addImage.title=Ajouter une image au PDF
-home.addImage.desc=Ajoute une image à un emplacement défini sur le PDF (Travail en cours)
-addImage.tags=img,jpg,picture,photo
+home.addImage.title=Ajouter une image
+home.addImage.desc=Ajoutez une image à un emplacement défini sur un PDF.
+addImage.tags=img,jpg,image,photo
 
 home.watermark.title=Ajouter un filigrane
-home.watermark.desc=Ajoutez un filigrane personnalisé à votre document PDF.
-watermark.tags=Text,repeating,label,own,copyright,trademark,img,jpg,picture,photo
+home.watermark.desc=Ajoutez un filigrane personnalisé à votre PDF.
+watermark.tags=texte,filigrane,label,propriété,droit d\u2019auteur,marque déposée,img,jpg,image,photo,copyright,trademark
 
-home.permissions.title=Modifier les autorisations
-home.permissions.desc=Modifier les permissions de votre document PDF
-permissions.tags=read,write,edit,print
+home.permissions.title=Modifier les permissions
+home.permissions.desc=Modifiez les permissions de votre PDF.
+permissions.tags=permissions,lire,écrire,modifier,imprimer,read,write,edit,print
 
 
 home.removePages.title=Supprimer
-home.removePages.desc=Supprimez les pages inutiles de votre document PDF.
-removePages.tags=Remove pages,delete pages
+home.removePages.desc=Supprimez les pages inutiles de votre PDF.
+removePages.tags=supprimer,remove,delete
 
 home.addPassword.title=Ajouter un mot de passe
-home.addPassword.desc=Cryptez votre document PDF avec un mot de passe.
-addPassword.tags=secure,security
+home.addPassword.desc=Chiffrez votre PDF avec un mot de passe.
+addPassword.tags=ajouter,sécurité,mot de passe,secure,security
 
 home.removePassword.title=Supprimer le mot de passe
-home.removePassword.desc=Supprimez la protection par mot de passe de votre document PDF.
-removePassword.tags=secure,Decrypt,security,unpassword,delete password
+home.removePassword.desc=Supprimez la protection par mot de passe de votre PDF.
+removePassword.tags=supprimer,sécurité,mot de passe,secure,decrypt,security,unpassword,delete password
 
 home.compressPdfs.title=Compresser
-home.compressPdfs.desc=Compressez les PDF pour réduire leur taille de fichier.
-compressPdfs.tags=squish,small,tiny
+home.compressPdfs.desc=Compressez les PDF pour réduire leur tailles.
+compressPdfs.tags=compresser,réduire,taille,squish,small,tiny
 
 
 home.changeMetadata.title=Modifier les métadonnées
-home.changeMetadata.desc=Modifier/Supprimer/Ajouter des métadonnées d'un document PDF
-changeMetadata.tags==Title,author,date,creation,time,publisher,producer,stats
+home.changeMetadata.desc=Modifiez, supprimez ou ajoutez des métadonnées à un PDF.
+changeMetadata.tags=métadonnées,titre,auteur,date,création,heure,éditeur,statistiques,title,author,date,creation,time,publisher,producer,stats,metadata
 
-home.fileToPDF.title=Convertir un fichier en PDF
-home.fileToPDF.desc=Convertissez presque n\u2019importe quel fichier en PDF (DOCX, PNG, XLS, PPT, TXT et plus)
-fileToPDF.tags=transformation,format,document,picture,slide,text,conversion,office,docs,word,excel,powerpoint
+home.fileToPDF.title=Fichier en PDF
+home.fileToPDF.desc=Convertissez presque n\u2019importe quel fichiers en PDF (DOCX, PNG, XLS, PPT, TXT et plus).
+fileToPDF.tags=convertion,transformation,format,document,image,slide,texte,conversion,office,docs,word,excel,powerpoint
 
-home.ocr.title=Exécuter l'OCR sur les scans PDF et/ou de nettoyage
-home.ocr.desc=Le nettoyage analyse et détecte le texte des images dans un PDF et le rajoute en tant que texte.
-ocr.tags=recognition,text,image,scan,read,identify,detection,editable
+home.ocr.title=OCR / Nettoyage des numérisations
+home.ocr.desc=Utilisez l\u2019OCR pour analyser et détecter le texte des images d\u2019un PDF et le rajouter en temps que tel.
+ocr.tags=ocr,reconnaissance,texte,image,numérisation,scan,read,identify,detection,editable
 
 
 home.extractImages.title=Extraire les images
-home.extractImages.desc=Extrait toutes les images d\u2019un PDF et les enregistre au format zip
-extractImages.tags=picture,photo,save,archive,zip,capture,grab
+home.extractImages.desc=Extrayez toutes les images d\u2019un PDF et enregistrez-les dans un ZIP.
+extractImages.tags=image,photo,save,archive,zip,capture,grab
 
-home.pdfToPDFA.title=Convertir PDF en PDF/A
-home.pdfToPDFA.desc=Convertir un PDF en PDF/A pour un stockage à long terme
-pdfToPDFA.tags=archive,long-term,standard,conversion,storage,preservation
+home.pdfToPDFA.title=PDF en PDF/A
+home.pdfToPDFA.desc=Convertir un PDF en PDF/A pour un stockage à long terme.
+pdfToPDFA.tags=convertion,archive,long-term,standard,conversion,storage,préservation,preservation
 
-home.PDFToWord.title=PDF vers Word
-home.PDFToWord.desc=Convertir les formats PDF en Word (DOC, DOCX et ODT)
+home.PDFToWord.title=PDF en Word
+home.PDFToWord.desc=Convertissez un PDF en Word (DOC, DOCX et ODT).
 PDFToWord.tags=doc,docx,odt,word,transformation,format,conversion,office,microsoft,docfile
 
-home.PDFToPresentation.title=PDF vers présentation
-home.PDFToPresentation.desc=Convertir des PDF en formats de présentation (PPT, PPTX et ODP)
-PDFToPresentation.tags=slides,show,office,microsoft
+home.PDFToPresentation.title=PDF en formats de présentation
+home.PDFToPresentation.desc=Convertissez un PDF en format de présentation (PPT, PPTX et ODP).
+PDFToPresentation.tags=présentation,slides,show,office,microsoft
 
-home.PDFToText.title=PDF vers texte/RTF
-home.PDFToText.desc=Convertir un PDF au format Texte ou RTF
+home.PDFToText.title=PDF en RTF (texte)
+home.PDFToText.desc=Convertissez un PDF au format RTF (texte).
 PDFToText.tags=richformat,richtextformat,rich text format
 
-home.PDFToHTML.title=PDF vers HTML
-home.PDFToHTML.desc=Convertir le PDF au format HTML
-PDFToHTML.tags=web content,browser friendly
+home.PDFToHTML.title=PDF en HTML
+home.PDFToHTML.desc=Convertissez un PDF au format HTML.
+PDFToHTML.tags=html,web content,browser friendly
 
 
-home.PDFToXML.title=PDF vers XML
-home.PDFToXML.desc=Convertir le PDF au format XML
-PDFToXML.tags=data-extraction,structured-content,interop,transformation,convert
+home.PDFToXML.title=PDF en XML
+home.PDFToXML.desc=Convertissez un PDF au format XML.
+PDFToXML.tags=xml,extraction de données,contenu structuré,interopérabilité,data-extraction,structured-content,interop,transformation,convert
 
-home.ScannerImageSplit.title=Détecter/diviser les photos numérisées
-home.ScannerImageSplit.desc=Divise plusieurs photos à partir d'une photo/PDF
-ScannerImageSplit.tags=separate,auto-detect,scans,multi-photo,organize
+home.ScannerImageSplit.title=Diviser les photos numérisées
+home.ScannerImageSplit.desc=Divisez plusieurs photos à partir d\u2019une photo ou d\u2019un PDF.
+ScannerImageSplit.tags=diviser,détecter automatiquement,numériser,separate,auto-detect,scans,multi-photo,organize
 
-home.sign.title=Signe
-home.sign.desc=Ajoute une signature au PDF par dessin, texte ou image
-sign.tags=authorize,initials,drawn-signature,text-sign,image-signature
+home.sign.title=Signer
+home.sign.desc=Ajoutez une signature au PDF avec un dessin, du texte ou une image.
+sign.tags=signer,authorize,initials,drawn-signature,text-sign,image-signature
 
-home.flatten.title=Aplatir
-home.flatten.desc=Supprimer tous les éléments et formulaires interactifs d'un PDF
-flatten.tags=static,deactivate,non-interactive,streamline
+home.flatten.title=Rendre inerte
+home.flatten.desc=Supprimez tous les éléments et formulaires interactifs d\u2019un PDF.
+flatten.tags=inerte,static,deactivate,non-interactive,streamline
 
 home.repair.title=Réparer
-home.repair.desc=Essaye de réparer un PDF corrompu/cassé
-repair.tags=fix,restore,correction,recover
+home.repair.desc=Essayez de réparer un PDF corrompu ou cassé.
+repair.tags=réparer,restaurer,corriger,récupérer,fix,restore,correction,recover
 
 home.removeBlanks.title=Supprimer les pages vierges
-home.removeBlanks.desc=Détecte et supprime les pages vierges d'un document
-removeBlanks.tags=cleanup,streamline,non-content,organize
+home.removeBlanks.desc=Détectez et supprimez les pages vierges d\u2019un PDF.
+removeBlanks.tags=pages vierges,supprimer,nettoyer,cleanup,streamline,non-content,organize
 
 home.compare.title=Comparer
-home.compare.desc=Compare et affiche les différences entre 2 documents PDF
-compare.tags=differentiate,contrast,changes,analysis
+home.compare.desc=Comparez et visualisez les différences entre deux PDF.
+compare.tags=comparer,analyser,differentiate,contrast,changes,analysis
 
-home.certSign.title=Sign with Certificate
-home.certSign.desc=Signs a PDF with a Certificate/Key (PEM/P12)
-certSign.tags=authenticate,PEM,P12,official,encrypt
+home.certSign.title=Signer avec un certificat
+home.certSign.desc=Signez un PDF avec un certificat ou une clé (PEM/P12).
+certSign.tags=signer,chiffrer,certificat,authenticate,PEM,P12,official,encrypt
 
-home.pageLayout.title=Multi-Page Layout
-home.pageLayout.desc=Merge multiple pages of a PDF document into a single page
-pageLayout.tags=merge,composite,single-view,organize
+home.pageLayout.title=Fusionner des pages
+home.pageLayout.desc=Fusionnez plusieurs pages d\u2019un PDF en une seule.
+pageLayout.tags=fusionner,merge,composite,single-view,organize
 
-home.scalePages.title=Adjust page size/scale
-home.scalePages.desc=Change the size/scale of page and/or its contents.
-scalePages.tags=resize,modify,dimension,adapt
+home.scalePages.title=Ajuster l\u2019échelle ou la taille
+home.scalePages.desc=Modifiez la taille ou l\u2019échelle d\u2019une page et/ou de son contenu.
+scalePages.tags=ajuster,redimensionner,resize,modify,dimension,adapt
 
-home.pipeline.title=Pipeline (Advanced)
-home.pipeline.desc=Run multiple actions on PDFs by defining pipeline scripts
-pipeline.tags=automate,sequence,scripted,batch-process
+home.pipeline.title=Pipeline (avancé)
+home.pipeline.desc=Exécutez plusieurs actions sur les PDF en définissant des scripts de pipeline.
+pipeline.tags=automatiser,séquencer,automate,sequence,scripted,batch-process
 
-home.add-page-numbers.title=Add Page Numbers
-home.add-page-numbers.desc=Add Page numbers throughout a document in a set location
-add-page-numbers.tags=paginate,label,organize,index
+home.add-page-numbers.title=Ajouter des numéros de page
+home.add-page-numbers.desc=Ajoutez des numéros de page dans un PDF à un emplacement défini.
+add-page-numbers.tags=paginer,numéros,étiqueter,paginate,label,organize,index
 
-home.auto-rename.title=Auto Rename PDF File
-home.auto-rename.desc=Auto renames a PDF file based on its detected header
-auto-rename.tags=auto-detect,header-based,organize,relabel
+home.auto-rename.title=Renommer automatiquement
+home.auto-rename.desc=Renommez automatiquement un fichier PDF en fonction de son en-tête détecté.
+auto-rename.tags=renommer,détection automatique,réétiqueter,auto-detect,header-based,organize,relabel
 
-home.adjust-contrast.title=Adjust Colors/Contrast
-home.adjust-contrast.desc=Adjust Contrast, Saturation and Brightness of a PDF
-adjust-contrast.tags=color-correction,tune,modify,enhance
+home.adjust-contrast.title=Ajuster les couleurs
+home.adjust-contrast.desc=Ajustez le contraste, la saturation et la luminosité d\u2019un PDF.
+adjust-contrast.tags=ajuster,couleurs,amélioration,color-correction,tune,modify,enhance
 
-home.crop.title=Crop PDF
-home.crop.desc=Crop a PDF to reduce its size (maintains text!)
-crop.tags=trim,shrink,edit,shape
+home.crop.title=Redimensionner
+home.crop.desc=Redimmensionnez un PDF pour réduire sa taille (en conservant le texte\u00a0!).
+crop.tags=redimensionner,trim,shrink,edit,shape
 
-home.autoSplitPDF.title=Auto Split Pages
-home.autoSplitPDF.desc=Auto Split Scanned PDF with physical scanned page splitter QR Code
-autoSplitPDF.tags=QR-based,separate,scan-segment,organize
+home.autoSplitPDF.title=Séparer automatiquement les pages
+home.autoSplitPDF.desc=Séparez automatiquement le PDF numérisé avec le code QR du diviseur de page numérisé.
+autoSplitPDF.tags=séparer,QR-based,separate,scan-segment,organize
 
-home.sanitizePdf.title=Sanitize
-home.sanitizePdf.desc=Remove scripts and other elements from PDF files
-sanitizePdf.tags=clean,secure,safe,remove-threats
+home.sanitizePdf.title=Assainir
+home.sanitizePdf.desc=Supprimez les scripts et autres éléments des PDF.
+sanitizePdf.tags=assainir,sécurisé,clean,secure,safe,remove-threats
 
-home.URLToPDF.title=URL/Website To PDF
-home.URLToPDF.desc=Converts any http(s)URL to PDF
-URLToPDF.tags=web-capture,save-page,web-to-doc,archive
+home.URLToPDF.title=URL en PDF
+home.URLToPDF.desc=Convertissez n\u2019importe quelle URL http(s) en PDF.
+URLToPDF.tags=pdf,contenu Web,save-page,web-to-doc,archive
 
-home.HTMLToPDF.title=HTML to PDF
-home.HTMLToPDF.desc=Converts any HTML file or zip to PDF
-HTMLToPDF.tags=markup,web-content,transformation,convert
-
-
-home.MarkdownToPDF.title=Markdown to PDF
-home.MarkdownToPDF.desc=Converts any Markdown file to PDF
-MarkdownToPDF.tags=markup,web-content,transformation,convert
+home.HTMLToPDF.title=HTML en PDF
+home.HTMLToPDF.desc=Convertissez n\u2019importe quel fichier HTML ou ZIP en PDF.
+HTMLToPDF.tags=html,markup,contenu Web,transformation,convert
 
 
-home.getPdfInfo.title=Get ALL Info on PDF
-home.getPdfInfo.desc=Grabs any and all information possible on PDFs
-getPdfInfo.tags=infomation,data,stats,statistics
+home.MarkdownToPDF.title=Markdown en PDF
+home.MarkdownToPDF.desc=Convertissez n\u2019importe quel fichier Markdown en PDF.
+MarkdownToPDF.tags=markdown,markup,contenu Web,transformation,convert
 
 
-home.extractPage.title=Extract page(s)
-home.extractPage.desc=Extracts select pages from PDF
-extractPage.tags=extract
+home.getPdfInfo.title=Récupérer les informations
+home.getPdfInfo.desc=Récupérez toutes les informations possibles sur un PDF.
+getPdfInfo.tags=récupérer,infomation,data,stats,statistics
 
 
-home.PdfToSinglePage.title=PDF to Single Large Page
-home.PdfToSinglePage.desc=Merges all PDF pages into one large single page
-PdfToSinglePage.tags=single page
+home.extractPage.title=Extraire des pages
+home.extractPage.desc=Extrayez certaines pages du PDF.
+extractPage.tags=extraire,extract
 
 
-##########################
-###  TODO: Translate   ###
-##########################
-home.showJS.title=Show Javascript
-home.showJS.desc=Searches and displays any JS injected into a PDF
-showJS.tags=JS
+home.PdfToSinglePage.title=Fusionner en une seule page
+home.PdfToSinglePage.desc=Fusionnez toutes les pages PDF en une seule grande page.
+PdfToSinglePage.tags=fusionner,merge,une seule page,single page
+
+
+home.showJS.title=Afficher le JavaScript
+home.showJS.desc=Recherche et affiche tout JavaScript injecté dans un PDF.
+showJS.tags=afficher,javascript,js
 
 ###########################
 #                         #
@@ -269,115 +266,105 @@ showJS.tags=JS
 #                         #
 ###########################
 #showJS
-##########################
-###  TODO: Translate   ###
-##########################
-showJS.title=Show Javascript
-showJS.header=Show Javascript
-showJS.downloadJS=Download Javascript
-showJS.submit=Show
+showJS.title=Afficher le JavaScript
+showJS.header=Afficher le JavaScript
+showJS.downloadJS=Télécharger le JavaScript
+showJS.submit=Afficher
 
 
 #pdfToSinglePage
-pdfToSinglePage.title=PDF To Single Page
-pdfToSinglePage.header=PDF To Single Page
-pdfToSinglePage.submit=Convert To Single Page
-
-
-#pageExtracter
-pageExtracter.title=Extract Pages
-pageExtracter.header=Extract Pages
-pageExtracter.submit=Extract
+pdfToSinglePage.title=Fusionner des pages
+pdfToSinglePage.header=Fusionner des pages
+pdfToSinglePage.submit=Convertir en une seule page
 
 
 #getPdfInfo
-getPdfInfo.title=Get Info on PDF
-getPdfInfo.header=Get Info on PDF
-getPdfInfo.submit=Get Info
-getPdfInfo.downloadJson=Download JSON
+getPdfInfo.title=Récupérer les informations
+getPdfInfo.header=Récupérer les informations
+getPdfInfo.submit=Récupérer les informations
+getPdfInfo.downloadJson=Télécharger le JSON
 
 
 #markdown-to-pdf
-MarkdownToPDF.title=Markdown To PDF
-MarkdownToPDF.header=Markdown To PDF
-MarkdownToPDF.submit=Convert
-MarkdownToPDF.help=Work in progress
-MarkdownToPDF.credit=Uses WeasyPrint
-
+MarkdownToPDF.title=Markdown en PDF
+MarkdownToPDF.header=Markdown en PDF
+MarkdownToPDF.submit=Convertir
+MarkdownToPDF.help=(Travail en cours).
+MarkdownToPDF.credit=Utilise WeasyPrint.
 
 
 #url-to-pdf
-URLToPDF.title=URL To PDF
-URLToPDF.header=URL To PDF
-URLToPDF.submit=Convert
-URLToPDF.credit=Uses WeasyPrint
+URLToPDF.title=URL en PDF
+URLToPDF.header=URL en PDF
+URLToPDF.submit=Convertir
+URLToPDF.credit=Utilise WeasyPrint.
 
 
 #html-to-pdf
-HTMLToPDF.title=HTML To PDF
-HTMLToPDF.header=HTML To PDF
-HTMLToPDF.help=Accepts HTML files and ZIPs containing html/css/images etc required
-HTMLToPDF.submit=Convert
-HTMLToPDF.credit=Uses WeasyPrint
+HTMLToPDF.title=HTML en PDF
+HTMLToPDF.header=HTML en PDF
+HTMLToPDF.help=Accepte les fichiers HTML et les ZIP contenant du HTML, du CSS, des images, etc. (requis).
+HTMLToPDF.submit=Convertir
+HTMLToPDF.credit=Utilise WeasyPrint.
 
 
 #sanitizePDF
-sanitizePDF.title=Sanitize PDF
-sanitizePDF.header=Sanitize a PDF file
-sanitizePDF.selectText.1=Remove JavaScript actions
-sanitizePDF.selectText.2=Remove embedded files
-sanitizePDF.selectText.3=Remove metadata
-sanitizePDF.selectText.4=Remove links
-sanitizePDF.selectText.5=Remove fonts
-sanitizePDF.submit=Sanitize PDF
+sanitizePDF.title=Assainir
+sanitizePDF.header=Assainir
+sanitizePDF.selectText.1=Supprimer les actions JavaScript
+sanitizePDF.selectText.2=Supprimer les fichiers intégrés
+sanitizePDF.selectText.3=Supprimer les métadonnées
+sanitizePDF.selectText.4=Supprimer les liens
+sanitizePDF.selectText.5=Supprimer les polices
+sanitizePDF.submit=Assainir
 
 
 #addPageNumbers
-addPageNumbers.title=Add Page Numbers
-addPageNumbers.header=Add Page Numbers
-addPageNumbers.selectText.1=Select PDF file:
-addPageNumbers.selectText.2=Margin Size
+addPageNumbers.title=Ajouter des numéros de page
+addPageNumbers.header=Ajouter des numéros de page
+addPageNumbers.selectText.1=Sélectionnez le fichier PDF
+addPageNumbers.selectText.2=Taille de la marge
 addPageNumbers.selectText.3=Position
-addPageNumbers.selectText.4=Starting Number
-addPageNumbers.selectText.5=Pages to Number
-addPageNumbers.selectText.6=Custom Text
-addPageNumbers.submit=Add Page Numbers
+addPageNumbers.selectText.4=Numéro de départ
+addPageNumbers.selectText.5=Pages à numéroter
+addPageNumbers.selectText.6=Texte personnalisé
+addPageNumbers.submit=Ajouter les numéros de page
 
 
 #auto-rename
-auto-rename.title=Auto Rename
-auto-rename.header=Auto Rename PDF
-auto-rename.submit=Auto Rename
+auto-rename.title=Renommer automatiquement
+auto-rename.header=Renommer automatiquement
+auto-rename.submit=Renommer automatiquement
 
 
 #adjustContrast
-adjustContrast.title=Adjust Contrast
-adjustContrast.header=Adjust Contrast
-adjustContrast.contrast=Contrast:
-adjustContrast.brightness=Brightness:
-adjustContrast.saturation=Saturation:
-adjustContrast.download=Download
+adjustContrast.title=Ajuster les couleurs
+adjustContrast.header=Ajuster les couleurs
+adjustContrast.contrast=Contraste
+adjustContrast.brightness=Luminosité
+adjustContrast.saturation=Saturation
+adjustContrast.download=Télécharger
 
 
 #crop
-crop.title=Crop
-crop.header=Crop Image
-crop.submit=Submit
+crop.title=Redimensionner
+crop.header=Redimensionner
+crop.submit=Soumettre
 
 
 #autoSplitPDF
-autoSplitPDF.title=Auto Split PDF
-autoSplitPDF.header=Auto Split PDF
-autoSplitPDF.description=Print, Insert, Scan, upload, and let us auto-separate your documents. No manual work sorting needed.
-autoSplitPDF.selectText.1=Print out some divider sheets from below (Black and white is fine).
-autoSplitPDF.selectText.2=Scan all your documents at once by inserting the divider sheet between them.
-autoSplitPDF.selectText.3=Upload the single large scanned PDF file and let Stirling PDF handle the rest.
-autoSplitPDF.selectText.4=Divider pages are automatically detected and removed, guaranteeing a neat final document.
-autoSplitPDF.formPrompt=Submit PDF containing Stirling-PDF Page dividers:
-autoSplitPDF.duplexMode=Duplex Mode (Front and back scanning)
-autoSplitPDF.dividerDownload1=Download 'Auto Splitter Divider (minimal).pdf'
-autoSplitPDF.dividerDownload2=Download 'Auto Splitter Divider (with instructions).pdf'
-autoSplitPDF.submit=Submit
+autoSplitPDF.title=Séparer automatiquement les pages
+autoSplitPDF.header=Séparer automatiquement les pages
+autoSplitPDF.description=Imprimez, insérez, numérisez, téléchargez et laissez-nous séparer automatiquement vos documents. Aucun travail de tri manuel nécessaire.
+autoSplitPDF.selectText.1=Imprimez des feuilles de séparation ci-dessous (le mode noir et blanc convient).
+autoSplitPDF.selectText.2=Numérisez tous vos documents en une seule fois en insérant les feuilles intercalaires entre eux.
+autoSplitPDF.selectText.3=Téléchargez le fichier PDF numérisé et laissez Stirling PDF s\u2019occuper du reste.
+autoSplitPDF.selectText.4=Les feuilles de séparation sont automatiquement détectées et supprimées, garantissant un document final soigné.
+autoSplitPDF.formPrompt=PDF contenant des feuilles de séparation de Stirling PDF\u00a0:
+autoSplitPDF.duplexMode=Mode recto-verso
+autoSplitPDF.dividerDownload1=Auto Splitter Divider (minimal).pdf
+autoSplitPDF.dividerDownload2=Auto Splitter Divider (with instructions).pdf
+autoSplitPDF.submit=Séparer
 
 
 #pipeline
@@ -385,350 +372,330 @@ pipeline.title=Pipeline
 
 
 #pageLayout
-pageLayout.title=Multi Page Layout
-pageLayout.header=Multi Page Layout
-pageLayout.pagesPerSheet=Pages per sheet:
-pageLayout.submit=Submit
+pageLayout.title=Fusionner des pages
+pageLayout.header=Fusionner des pages
+pageLayout.pagesPerSheet=Pages par feuille
+pageLayout.submit=Fusionner
 
 
 #scalePages
-scalePages.title=Adjust page-scale
-scalePages.header=Adjust page-scale
-scalePages.pageSize=Size of a page of the document.
-scalePages.scaleFactor=Zoom level (crop) of a page.
-scalePages.submit=Submit
+scalePages.title=Ajuster la taille ou l\u2019échelle
+scalePages.header=Ajuster la taille ou l\u2019échelle
+scalePages.pageSize=Taille d\u2019une page du document
+scalePages.scaleFactor=Niveau de zoom (recadrage) d\u2019une page
+scalePages.submit=Ajuster
 
 
 #certSign
-certSign.title=Signature du certificat
-certSign.header=Signer un PDF avec votre certificat (Travail en cours)
-certSign.selectPDF=Sélectionnez un fichier PDF à signer :
-certSign.selectKey=Sélectionnez votre fichier de clé privée (format PKCS#8, peut être .pem ou .der) :
-certSign.selectCert=Sélectionnez votre fichier de certificat (format X.509, peut être .pem ou .der) :
-certSign.selectP12=Sélectionnez votre fichier de magasin de clés PKCS#12 (.p12 ou .pfx) (facultatif, s'il est fourni, il doit contenir votre clé privée et votre certificat) :
+certSign.title=Signer avec un certificat
+certSign.header=Signer avec un certificat (Travail en cours)
+certSign.selectPDF=PDF à signer
+certSign.selectKey=Fichier de clé privée (format PKCS#8, peut être .pem ou .der)
+certSign.selectCert=Fichier de certificat (format X.509, peut être .pem ou .der)
+certSign.selectP12=Fichier keystore de clés PKCS#12 (.p12 ou .pfx) (facultatif, s\u2019il n\u2019est fourni, il doit contenir votre clé privée et votre certificat)
 certSign.certType=Type de certificat
-certSign.password=Entrez votre mot de passe de keystore ou de clé privée (le cas échéant) :
+certSign.password=Mot de passe keystore ou clé privée le cas échéant
 certSign.showSig=Afficher la signature
 certSign.reason=Raison
 certSign.location=Emplacement
 certSign.name=Nom
-certSign.submit=Signer le PDF
+certSign.submit=Signer
 
 
 #removeBlanks
-removeBlanks.title=Supprimer les blancs
+removeBlanks.title=Supprimer les pages vierges
 removeBlanks.header=Supprimer les pages vierges
-removeBlanks.threshold=Seuil :
-removeBlanks.thresholdDesc=Seuil pour déterminer à quel point un pixel blanc doit être blanc
-removeBlanks.whitePercent=Pourcentage blanc (%) :
-removeBlanks.whitePercentDesc=Pourcentage de page qui doit être blanche pour être supprimée
-removeBlanks.submit=Supprimer les blancs
+removeBlanks.threshold=Seuil de blancheur des pixels
+removeBlanks.thresholdDesc=Seuil pour déterminer à quel point un pixel blanc doit être blanc pour être classé comme «\u00a0blanc\u00a0» (0 = noir, 255 = blanc pur).
+removeBlanks.whitePercent=Pourcentage de blanc
+removeBlanks.whitePercentDesc=Pourcentage de la page qui doit contenir des pixels « blancs » à supprimer.
+removeBlanks.submit=Supprimer les pages vierges
 
 
 #compare
 compare.title=Comparer
-compare.header=Comparer des PDF
+compare.header=Comparer
 compare.document.1=Document 1
 compare.document.2=Document 2
 compare.submit=Comparer
 
 
 #sign
-sign.title=Signe
-sign.header=Signer des PDF
-sign.upload=Télécharger l'image
+sign.title=Signer
+sign.header=Signer
+sign.upload=Télécharger une image
 sign.draw=Dessiner une signature
-sign.text=Saisie de texte
+sign.text=Saisir de texte
 sign.clear=Effacer
 sign.add=Ajouter
 
 
 #repair
 repair.title=Réparer
-repair.header=Réparer les PDF
+repair.header=Réparer
 repair.submit=Réparer
 
 
 #flatten
-flatten.title=Aplatir
-flatten.header=Aplatir les PDF
-flatten.submit=Aplatir
+flatten.title=Rendre inerte
+flatten.header=Rendre inerte
+flatten.submit=Rendre inerte
 
 
 #ScannerImageSplit
-ScannerImageSplit.selectText.1=Seuil d'angle :
-ScannerImageSplit.selectText.2=Définit l'angle absolu minimum requis pour la rotation de l'image (par défaut : 10).
-ScannerImageSplit.selectText.3=Tolérance :
-ScannerImageSplit.selectText.4=Détermine la plage de variation de couleur autour de la couleur d'arrière-plan estimée (par défaut : 30).
-ScannerImageSplit.selectText.5=Zone minimale :
-ScannerImageSplit.selectText.6=Définit le seuil de zone minimum pour une photo (par défaut : 10000).
-ScannerImageSplit.selectText.7=Zone de contour minimale :
-ScannerImageSplit.selectText.8=Définit le seuil de zone de contour minimum pour une photo
-ScannerImageSplit.selectText.9=Taille de la bordure :
-ScannerImageSplit.selectText.10=Définit la taille de la bordure ajoutée et supprimée pour éviter les bordures blanches dans la sortie (par défaut : 1).
+ScannerImageSplit.selectText.1=Seuil de rotation
+ScannerImageSplit.selectText.2=Définit l\u2019angle absolu minimum requis pour la rotation de l\u2019image (par défaut\u00a0: 10).
+ScannerImageSplit.selectText.3=Tolérance
+ScannerImageSplit.selectText.4=Détermine la plage de variation de couleur autour de la couleur d\u2019arrière-plan estimée (par défaut\u00a0: 20).
+ScannerImageSplit.selectText.5=Surface minimale
+ScannerImageSplit.selectText.6=Définit la surface minimale pour une photo (par défaut\u00a0: 8\u202f000).
+ScannerImageSplit.selectText.7=Surface de contour minimale
+ScannerImageSplit.selectText.8=Définit la surface de contour minimale pour une photo (par défaut\u00a0: 500).
+ScannerImageSplit.selectText.9=Taille de la bordure
+ScannerImageSplit.selectText.10=Définit la taille de la bordure ajoutée et supprimée pour éviter les bordures blanches dans la sortie (par défaut\u00a0: 1).
 
-                            
+
 #OCR
-ocr.title=OCR / Nettoyage de numérisation
-ocr.header=Nettoyage des scans / OCR (reconnaissance optique des caractères)
-ocr.selectText.1=Sélectionnez les langues à détecter dans le PDF (celles répertoriées sont celles actuellement détectées) :
-ocr.selectText.2=Produire un fichier texte contenant du texte OCR avec le PDF OCR
-ocr.selectText.3=Les pages correctes ont été numérisées à un angle oblique en les remettant en place
-ocr.selectText.4=Nettoyer la page pour qu'il soit moins probable que l'OCR trouve du texte dans le bruit de fond. (Pas de changement de sortie)
-ocr.selectText.5=Nettoyer la page afin qu'il soit moins probable que l'OCR trouve du texte dans le bruit de fond, maintient le nettoyage dans la sortie.
-ocr.selectText.6=Ignore les pages contenant du texte interactif, seulement les pages OCR qui sont des images
-ocr.selectText.7=Forcer l'OCR, OCR chaque page supprimera tous les éléments de texte d'origine
-ocr.selectText.8=Normal (Erreur si le PDF contient du texte)
-ocr.selectText.9=Paramètres supplémentaires
-ocr.selectText.10=Mode ROC
-ocr.selectText.11=Supprimer les images après l'OCR (Supprime TOUTES les images, utile uniquement si elles font partie de l'étape de conversion)
+ocr.title=OCR / Nettoyage des numérisations
+ocr.header=OCR (Reconnaissance optique de caractères) / Nettoyage des numérisations
+ocr.selectText.1=Langues à détecter dans le PDF (celles listées sont celles actuellement détectées)
+ocr.selectText.2=Produire un fichier texte contenant le texte détecté à côté du PDF
+ocr.selectText.3=Corriger les pages qui ont été numérisées à un angle oblique en les remettant en place
+ocr.selectText.4=Nettoyer la page afin qu\u2019il soit moins probable que l\u2019OCR trouve du texte dans le bruit de fond, sans modifier la sortie
+ocr.selectText.5=Nettoyer la page afin qu\u2019il soit moins probable que l\u2019OCR trouve du texte dans le bruit de fond, en modifiant la sortie
+ocr.selectText.6=Ignorer les pages contenant du texte interactif, n\u2019analyser que les pages qui sont des images
+ocr.selectText.7=Forcer l\u2019OCR, analyser chaque page et supprimer tous les éléments de texte d\u2019origine
+ocr.selectText.8=Normal (génère une erreur si le PDF contient du texte)
+ocr.selectText.9=Paramètres additionnels
+ocr.selectText.10=Mode OCR
+ocr.selectText.11=Supprimer les images après l\u2019OCR (Supprime TOUTES les images, utile uniquement si elles font partie de l\u2019étape de conversion)
 ocr.selectText.12=Type de rendu (avancé)
-ocr.help=Veuillez lire cette documentation pour savoir comment l'utiliser pour d'autres langues et/ou une utilisation non dans docker
-ocr.credit=Ce service utilise OCRmyPDF et Tesseract pour l'OCR.
-ocr.submit=Traiter PDF avec OCR
+ocr.help=Veuillez lire cette documentation pour savoir comment utiliser l\u2019OCR pour d\u2019autres langues ou une utilisation hors Docker\u00a0:
+ocr.credit=Ce service utilise OCRmyPDF et Tesseract pour l\u2019OCR.
+ocr.submit=Traiter
 
 
 #extractImages
 extractImages.title=Extraire les images
 extractImages.header=Extraire les images
-extractImages.selectText=Sélectionner le format d'image pour convertir les images extraites en
+extractImages.selectText=Format d\u2019image dans lequel convertir les images extraites
 extractImages.submit=Extraire
 
 
 #File to PDF
-fileToPDF.title=Fichier au format PDF
-fileToPDF.header=Convertir n'importe quel fichier au format PDF
+fileToPDF.title=Fichier en PDF
+fileToPDF.header=Convertir un fichier en PDF
 fileToPDF.credit=Ce service utilise LibreOffice et Unoconv pour la conversion de fichiers.
-fileToPDF.supportedFileTypes=Les types de fichiers pris en charge doivent inclure les éléments ci-dessous, mais pour une liste complète et mise à jour des formats pris en charge, veuillez vous référer à la documentation de LibreOffice.
-fileToPDF.submit=Convertir en PDF
+fileToPDF.supportedFileTypes=Les types de fichiers pris en charge doivent inclure les éléments ci-dessous, mais pour une liste complète et mise à jour des formats pris en charge, veuillez vous reporter à la documentation de LibreOffice.
+fileToPDF.submit=Convertir
 
 
 #compress
 compress.title=Compresser
-compress.header=Compresser le PDF
-compress.credit=Ce service utilise Ghostscript pour PDF Compress/Optimisation.
-compress.selectText.1=Mode manuel - De 1 à 4
-compress.selectText.2=Niveau d'optimisation :
-compress.selectText.3=4 (Terrible pour les images de texte)
-compress.selectText.4=Mode automatique - Ajuste automatiquement la qualité pour obtenir le PDF à la taille exacte
-compress.selectText.5=Taille PDF attendue (par exemple, 25 Mo, 10,8 Mo, 25 Ko)
+compress.header=Compresser
+compress.credit=Ce service utilise Ghostscript pour la compression et l\u2019optimisation des PDF.
+compress.selectText.1=Mode manuel \u2013 de 1 à 4
+compress.selectText.2=Niveau d\u2019optimisation
+compress.selectText.3=4 (terrible pour les images textuelles)
+compress.selectText.4=Mode automatique \u2013 ajuste automatiquement la qualité pour obtenir le PDF à la taille exacte
+compress.selectText.5=Taille PDF attendue (par exemple, 25\u202fMo, 10,8\u202fMo, 25\u202fKo)
 compress.submit=Compresser
 
 
 #Add image
 addImage.title=Ajouter une image
-addImage.header=Ajouter une image au PDF
-addImage.everyPage=Chaque page?
-addImage.upload=Ajouter une image
+addImage.header=Ajouter une image
+addImage.everyPage=Toutes les pages\u00a0?
+addImage.upload=Télécharger une image
 addImage.submit=Ajouter une image
 
 
 #merge
 merge.title=Fusionner
-merge.header=Fusionner plusieurs PDF (2+)
+merge.header=Fusionner plusieurs PDF
 merge.submit=Fusionner
 
 
 #pdfOrganiser
-pdfOrganiser.title=Organisateur de pages
-pdfOrganiser.header=Organisateur de pages PDF
-pdfOrganiser.submit=Réorganiser les pages
+pdfOrganiser.title=Organiser
+pdfOrganiser.header=Organiser les pages
+pdfOrganiser.submit=Organiser
 
 
 #multiTool
-multiTool.title=Multi-outil PDF
-multiTool.header=Outil multiple PDF
-
-
-#pageRemover
-pageRemover.title=Suppresseur de pages
-pageRemover.header=Outil de suppression de pages PDF
-pageRemover.pagesToDelete=Pages à supprimer (Entrez une liste de numéros de page séparés par des virgules):
-pageRemover.submit=Supprimer des pages
+multiTool.title=Outil multifonction PDF
+multiTool.header=Outil multifonction PDF
 
 
 #rotate
-rotate.title=Faire pivoter le PDF
-rotate.header=Faire pivoter le PDF
-rotate.selectAngle=Sélectionner l'angle de rotation (en multiples de 90 degrés) :
-rotate.submit=Rotation
+rotate.title=Pivoter
+rotate.header=Pivoter
+rotate.selectAngle=Angle de rotation (par multiples de 90\u202fdegrés)
+rotate.submit=Pivoter
 
 
-#merge
-split.title=Fractionner le PDF
-split.header=Diviser le PDF
-split.desc.1=Les numéros que vous sélectionnez sont le numéro de page sur lequel vous souhaitez faire un fractionnement.
-split.desc.2=Ainsi, la sélection de 1,3,7-8 diviserait un document de 10 pages en 6 PDF distincts avec :
-split.desc.3=Document #1 : Page 1
-split.desc.4=Document #2 : Pages 2 et 3
-split.desc.5=Document #3 : Pages 4, 5 et 6
-split.desc.6=Document #4 : Page 7
-split.desc.7=Document #5 : Page 8
-split.desc.8=Document #6 : Pages 9 et 10
-split.splitPages=Entrez les pages sur lesquelles fractionner :
+#split
+split.title=Diviser
+split.header=Diviser
+split.desc.1=Les numéros que vous sélectionnez sont le numéro de page sur lequel vous souhaitez faire une division
+split.desc.2=Ainsi, la sélection de 1,3,7-8 diviserait un document de 10 pages en 6 PDF distincts avec\u00a0:
+split.desc.3=Document #1: Page 1
+split.desc.4=Document #2: Page 2 et 3
+split.desc.5=Document #3: Page 4, 5 et 6
+split.desc.6=Document #4: Page 7
+split.desc.7=Document #5: Page 8
+split.desc.8=Document #6: Page 9 et 10
+split.splitPages=Pages sur lesquelles diviser
 split.submit=Diviser
 
 
-#merge
-imageToPDF.title=Image au format PDF
-imageToPDF.header=Image au format PDF
-imageToPDF.submit=Convertir
-imageToPDF.selectText.1=Étirer pour s'adapter
+#imageToPDF
+imageToPDF.title=Image en PDF
+imageToPDF.header=Image en PDF
+imageToPDF.selectText.1=Étirer pour adapter
 imageToPDF.selectText.2=Rotation automatique du PDF
-imageToPDF.selectText.3=Logique de fichiers multiples (activé uniquement si vous travaillez avec plusieurs images)
+imageToPDF.selectText.3=Logique multi-fichiers (uniquement activée si vous travaillez avec plusieurs images)
 imageToPDF.selectText.4=Fusionner en un seul PDF
-imageToPDF.selectText.5=Convertir en PDFs distincts
-    
-                                   
+imageToPDF.selectText.5=Convertir en PDF séparés
+imageToPDF.submit=Convertir
+
+
 #pdfToImage
-pdfToImage.title=PDF vers image
-pdfToImage.header=PDF vers image
-pdfToImage.selectText=Format d'image
-pdfToImage.singleOrMultiple=Type de résultat d'image
+pdfToImage.title=Image en PDF
+pdfToImage.header=Image en PDF
+pdfToImage.selectText=Format d\u2019image
+pdfToImage.singleOrMultiple=Type de résultat
 pdfToImage.single=Une seule grande image
 pdfToImage.multi=Plusieurs images
-pdfToImage.colorType=Type de couleur
+pdfToImage.colorType=Type d\u2019impression
 pdfToImage.color=Couleur
 pdfToImage.grey=Niveaux de gris
-pdfToImage.blackwhite=Noir et Blanc (Peut perdre des données !)
+pdfToImage.blackwhite=Noir et blanc (peut engendre une perde de données\u00a0!)
 pdfToImage.submit=Convertir
 
 
 #addPassword
 addPassword.title=Ajouter un mot de passe
-addPassword.header=Ajouter un mot de passe (chiffrer)
-addPassword.selectText.1=Sélectionnez le PDF à chiffrer
-addPassword.selectText.2=Mot de passe
+addPassword.header=Ajouter un mot de passe
+addPassword.selectText.1=PDF à chiffrer
+addPassword.selectText.2=Mot de passe de l\u2019utilisateur
 addPassword.selectText.3=Longueur de la clé de chiffrement
-addPassword.selectText.4=Les valeurs supérieures sont plus fortes, mais les valeurs inférieures ont une meilleure compatibilité.
-addPassword.selectText.5=Autorisations à définir
-addPassword.selectText.6=Empêcher l'assemblage du document
-addPassword.selectText.7=Empêcher l'extraction de contenu
-addPassword.selectText.8=Empêcher l'extraction pour l'accessibilité
-addPassword.selectText.9=Empêcher de remplir le formulaire
+addPassword.selectText.4=Les valeurs plus élevées sont plus fortes, mais les valeurs plus faibles ont une meilleure compatibilité.
+addPassword.selectText.5=Autorisations à définir (utilisation recommandée avec le mot de passe du propriétaire)
+addPassword.selectText.6=Empêcher l\u2019assemblage du document
+addPassword.selectText.7=Empêcher l\u2019extraction de contenu
+addPassword.selectText.8=Empêcher l\u2019extraction pour l\u2019accessibilité
+addPassword.selectText.9=Empêcher de remplir les formulaires
 addPassword.selectText.10=Empêcher la modification
 addPassword.selectText.11=Empêcher la modification des annotations
-addPassword.selectText.12=Empêcher l'impression
-addPassword.selectText.13=Empêcher l'impression de différents formats
-addPassword.selectText.14=Owner Password
-addPassword.selectText.15=Restricts what can be done with the document once it is opened (Not supported by all readers)
-addPassword.selectText.16=Restricts the opening of the document itself
-addPassword.submit=Crypter
+addPassword.selectText.12=Empêcher l\u2019impression
+addPassword.selectText.13=Empêcher l\u2019impression des différents formats
+addPassword.selectText.14=Mot de passe du propriétaire
+addPassword.selectText.15=Restreint ce qui peut être fait avec le document une fois qu\u2019il est ouvert (non pris en charge par tous les lecteurs).
+addPassword.selectText.16=Restreint l\u2019ouverture du document lui-même.
+addPassword.submit=Chiffrer
 
 
 #watermark
 watermark.title=Ajouter un filigrane
 watermark.header=Ajouter un filigrane
-watermark.selectText.1=Sélectionnez le PDF auquel ajouter un filigrane :
-watermark.selectText.2=Texte du filigrane :
-watermark.selectText.3=Taille de la police :
-watermark.selectText.4=Rotation (0-360) :
-watermark.selectText.5=widthSpacer (Espace entre chaque filigrane horizontalement) :
-watermark.selectText.6=heightSpacer (Espace entre chaque filigrane verticalement) :
-watermark.selectText.7=Opacité (0 % - 100 %) :
+watermark.selectText.1=PDF auquel ajouter un filigrane
+watermark.selectText.2=Texte du filigrane
+watermark.selectText.3=Taille de police
+watermark.selectText.4=Rotation (de 0 à 360 degrés)
+watermark.selectText.5=widthSpacer (espace entre chaque filigrane horizontalement)
+watermark.selectText.6=heightSpacer (espace entre chaque filigrane verticalement)
+watermark.selectText.7=Opacité (de 0% à 100%)
+watermark.selectText.8=Type de filigrane
+watermark.selectText.9=Image du filigrane
 watermark.submit=Ajouter un filigrane
 
 
-#remove-watermark
-remove-watermark.title=Supprimer le filigrane
-remove-watermark.header=Supprimer le filigrane
-remove-watermark.selectText.1=Sélectionnez le PDF pour supprimer le filigrane :
-remove-watermark.selectText.2=Texte du filigrane :
-remove-watermark.submit=Supprimer le filigrane
-
-
 #Change permissions
-permissions.title=Modifier les autorisations
-permissions.header=Modifier les autorisations
-permissions.warning=Attention pour que ces permissions soient immuables il est recommandé de les définir avec un mot de passe via la page add-password.
-permissions.selectText.1=Sélectionnez le PDF pour modifier les autorisations :
-permissions.selectText.2=Autorisations à définir :
-permissions.selectText.3=Employer l'assemblage du document
-permissions.selectText.4=Employer l'extraction de contenu
-permissions.selectText.5=Employer l'extraction pour l'accessibilité
-permissions.selectText.6=Employer pour remplir le formulaire
-permissions.selectText.7=Employer pour la modification
-permissions.selectText.8=Employer pour la modification des annotations
-permissions.selectText.9=Employer pour l'impression
-permissions.selectText.10=Empêcher l'impression de différents formats
-permissions.submit=Modificateur
+permissions.title=Modifier les permissions
+permissions.header=Modifier les permissions
+permissions.warning=Attention, pour que ces permissions soient immuables il est recommandé de les paramétrer avec un mot de passe via la page Ajouter un mot de passe.
+permissions.selectText.1=Sélectionnez le PDF
+permissions.selectText.2=Permissions à définir
+permissions.selectText.3=Empêcher l\u2019assemblage du document
+permissions.selectText.4=Empêcher l\u2019extraction de contenu
+permissions.selectText.5=Empêcher l\u2019extraction pour l\u2019accessibilité
+permissions.selectText.6=Empêcher de remplir les formulaires
+permissions.selectText.7=Empêcher la modification
+permissions.selectText.8=Empêcher la modification des annotations
+permissions.selectText.9=Empêcher l\u2019impression
+permissions.selectText.10=Empêcher l\u2019impression des différents formats
+permissions.submit=Modifier
 
 
 #remove password
 removePassword.title=Supprimer le mot de passe
-removePassword.header=Supprimer le mot de passe (Déchiffrer)
-removePassword.selectText.1=Sélectionnez le PDF à déchiffrer
+removePassword.header=Supprimer le mot de passe
+removePassword.selectText.1=Sélectionnez le PDF
 removePassword.selectText.2=Mot de passe
 removePassword.submit=Supprimer
 
 
 #changeMetadata
-changeMetadata.title=Titre :
+changeMetadata.title=Modifier les métadonnées
 changeMetadata.header=Modifier les métadonnées
 changeMetadata.selectText.1=Veuillez modifier les variables que vous souhaitez modifier.
-changeMetadata.selectText.2=Supprimer toutes les métadonnées.
-changeMetadata.selectText.3=Afficher les métadonnées personnalisées :
-changeMetadata.author=Auteur :
-changeMetadata.creationDate=Date de création (aaaa/MM/jj HH:mm:ss) :
-changeMetadata.creator=Créateur :
-changeMetadata.keywords=Mots clés :
-changeMetadata.modDate=Date de modification (aaaa/MM/jj HH:mm:ss) :
-changeMetadata.producer=Producteur :
-changeMetadata.subject=Objet :
-changeMetadata.title=Titre :
-changeMetadata.trapped=Piégé :
-changeMetadata.selectText.4=Autres métadonnées :
-changeMetadata.selectText.5=Ajouter une entrée de métadonnées personnalisées
+changeMetadata.selectText.2=Supprimer toutes les métadonnées
+changeMetadata.selectText.3=Afficher des métadonnées personnalisées
+changeMetadata.author=Auteur
+changeMetadata.creationDate=Date de création (yyyy/MM/dd HH:mm:ss)
+changeMetadata.creator=Créateur
+changeMetadata.keywords=Mots clés
+changeMetadata.modDate=Date de modification (yyyy/MM/dd HH:mm:ss)
+changeMetadata.producer=Producteur
+changeMetadata.subject=Sujet
+changeMetadata.title=Titre
+changeMetadata.trapped=Défoncé (technique d’impression)
+changeMetadata.selectText.4=Autres métadonnées
+changeMetadata.selectText.5=Ajouter une entrée de métadonnées personnalisée
 changeMetadata.submit=Modifier
 
 
-#xlsToPdf
-xlsToPdf.title=Excel vers PDF
-xlsToPdf.header=Excel en PDF
-xlsToPdf.selectText.1=Sélectionnez une feuille Excel XLS ou XLSX à convertir.
-xlsToPdf.convert=Convertir
-
-
 #pdfToPDFA
-pdfToPDFA.title=PDF vers PDF/A
-pdfToPDFA.header=PDF vers PDF/A
-pdfToPDFA.credit=Ce service utilise OCRmyPDF pour la conversion PDF/A
+pdfToPDFA.title=PDF en PDF/A
+pdfToPDFA.header=PDF en PDF/A
+pdfToPDFA.credit=Ce service utilise OCRmyPDF pour la conversion en PDF/A.
 pdfToPDFA.submit=Convertir
 
 
 #PDFToWord
-PDFToWord.title=PDF vers Word
-PDFToWord.header=PDF vers Word
+PDFToWord.title=PDF en Word
+PDFToWord.header=PDF en Word
 PDFToWord.selectText.1=Format du fichier de sortie
 PDFToWord.credit=Ce service utilise LibreOffice pour la conversion de fichiers.
 PDFToWord.submit=Convertir
 
 
 #PDFToPresentation
-PDFToPresentation.title=PDF vers présentation
-PDFToPresentation.header=PDF vers présentation
+PDFToPresentation.title=PDF en formats de présentation
+PDFToPresentation.header=PDF en formats de présentation
 PDFToPresentation.selectText.1=Format du fichier de sortie
 PDFToPresentation.credit=Ce service utilise LibreOffice pour la conversion de fichiers.
 PDFToPresentation.submit=Convertir
 
 
 #PDFToText
-PDFToText.title=PDF vers Texte/RTF
-PDFToText.header=PDF vers texte/RTF
+PDFToText.title=PDF en RTF (texte)
+PDFToText.header=PDF en RTF (texte)
 PDFToText.selectText.1=Format du fichier de sortie
 PDFToText.credit=Ce service utilise LibreOffice pour la conversion de fichiers.
 PDFToText.submit=Convertir
 
 
 #PDFToHTML
-PDFToHTML.title=PDF vers HTML
-PDFToHTML.header=PDF vers HTML
+PDFToHTML.title=PDF en HTML
+PDFToHTML.header=PDF en HTML
 PDFToHTML.credit=Ce service utilise LibreOffice pour la conversion de fichiers.
 PDFToHTML.submit=Convertir
 
 
 #PDFToXML
-PDFToXML.title=PDF vers XML
-PDFToXML.header=PDF vers XML
+PDFToXML.title=PDF en XML
+PDFToXML.header=PDF en XML
 PDFToXML.credit=Ce service utilise LibreOffice pour la conversion de fichiers.
 PDFToXML.submit=Convertir


### PR DESCRIPTION
Improve French translations and add missing keys.

For future reference, here are the typographic rules I followed:

- replace simple quotes (`'`) with apostrophes (`\u2019`, rendered `’`)
- use non-breaking spaces (`\u00a0`) before colons, question marks or exclamation marks
- use narrow non-breaking spaces (`\u202f`) for spaces between numbers and units
- add full stops at the end of descriptions
- use "vouvoiement" for addressing the user
- use french quotation marks `«` and `»` with non-breaking spaces
- use middle dash `\u2013` for enumerations
- use imperative for labels
- avoid colons for labels