### PR TITLE
Removed numpy library from detect-blank-pages.py

### DIFF
--- a/scripts/detect-blank-pages.py
+++ b/scripts/detect-blank-pages.py
@@ -1,5 +1,4 @@
 import cv2
-import numpy as np
 import sys
 import argparse
 


### PR DESCRIPTION
Correct me if I'm wrong, but it looks like numpy is not used to detect blank pages.
This PR just removes the line that imports numpy from the detect-blank-pages.py script. 

I built the container with these changes and it worked fine. 