### PR TITLE
Fix help text in addPageNumbers.customNumberDesc

### DIFF
--- a/src/main/resources/messages_de_DE.properties
+++ b/src/main/resources/messages_de_DE.properties
@@ -430,7 +430,7 @@ addPageNumbers.selectText.5=Seiten zu nummerieren
 addPageNumbers.selectText.6=Benutzerdefinierter Text
 addPageNumbers.customTextDesc=Benutzerdefinierter Text
 addPageNumbers.numberPagesDesc=Welche Seiten nummeriert werden sollen, Standardeinstellung 'alle' ('all'), akzeptiert auch 1-5 oder 2,5,9 usw.
-addPageNumbers.customNumberDesc=Standardmäßig {n}, akzeptiert auch 'Seite {n} von {insgesamt}', 'Text-{n}', '{Dateiname}-{n} ('{filename}-{n})
+addPageNumbers.customNumberDesc=Standardmäßig {n}, akzeptiert auch 'Seite {n} von {total}', 'Text-{n}', '{filename}-{n}'
 addPageNumbers.submit=Seitenzahlen hinzufügen
 
 

--- a/src/main/resources/messages_es_ES.properties
+++ b/src/main/resources/messages_es_ES.properties
@@ -429,8 +429,8 @@ addPageNumbers.selectText.4=Número de inicio
 addPageNumbers.selectText.5=Páginas a numerar
 addPageNumbers.selectText.6=Texto personalizado
 addPageNumbers.customTextDesc=Texto personalizado
-addPageNumbers.numberPagesDesc=Qué páginas numerar, por defecto 'todas', también acepta 1-5 o 2,5,9 etc
-addPageNumbers.customNumberDesc=Por defecto a {n}, también acepta 'Página {n} de {total}', 'Texto-{n}', '{nombre de archivo}-{n}
+addPageNumbers.numberPagesDesc=Qué páginas numerar, por defecto 'all', también acepta 1-5 o 2,5,9 etc
+addPageNumbers.customNumberDesc=Por defecto a {n}, también acepta 'Página {n} de {total}', 'Texto-{n}', '{filename}-{n}
 addPageNumbers.submit=Añadir Números de Página
 
 

--- a/src/main/resources/messages_it_IT.properties
+++ b/src/main/resources/messages_it_IT.properties
@@ -429,8 +429,8 @@ addPageNumbers.selectText.4=Numero di partenza
 addPageNumbers.selectText.5=Pagine da numerare
 addPageNumbers.selectText.6=Testo personalizzato
 addPageNumbers.customTextDesc=Testo personalizzato
-addPageNumbers.numberPagesDesc=Quali pagine numerare, impostazione predefinita "tutte", accetta anche 1-5 o 2,5,9 ecc
-addPageNumbers.customNumberDesc=Il valore predefinito è {n}, accetta anche 'Pagina {n} di {totale}', 'Testo-{n}', '{nomefile}-{n}
+addPageNumbers.numberPagesDesc=Quali pagine numerare, impostazione predefinita "all", accetta anche 1-5 o 2,5,9 ecc
+addPageNumbers.customNumberDesc=Il valore predefinito è {n}, accetta anche 'Pagina {n} di {total}', 'Testo-{n}', '{filename}-{n}
 addPageNumbers.submit=Aggiungi numeri di pagina
 
 


### PR DESCRIPTION
The help text `addPageNumbers.customNumberDesc` was missleading in some languges.
E.g. German: {insgesamt} was not the corret keyword for {total}

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
