### PR TITLE
ci: add helm package/push to Jenkinsfile

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -140,3 +140,7 @@ jobs:
         tags: ${{ steps.meta3.outputs.tags }}
         labels: ${{ steps.meta3.outputs.labels }}
         platforms: linux/amd64,linux/arm64/v8
+    - name: Build and Push Helm Chart
+      run: |
+        helm package chart/stirling-pdf
+        helm push stirling-pdf-chart-1.0.0.tgz oci://registry-1.docker.io/frooodle

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,12 +22,24 @@ pipeline {
                     def appVersion = sh(returnStdout: true, script: './gradlew printVersion -q').trim()
                     def image = "frooodle/s-pdf:$appVersion"
                     withCredentials([string(credentialsId: 'docker_hub_access_token', variable: 'DOCKER_HUB_ACCESS_TOKEN')]) {
-				sh "docker login --username frooodle --password $DOCKER_HUB_ACCESS_TOKEN"
+				        sh "docker login --username frooodle --password $DOCKER_HUB_ACCESS_TOKEN"
                         sh "docker push $image"
                     }
                 }
             }
-    	
-	}
-   }
+        }
+        stage('Helm Push') {
+            steps {
+                script {
+                    //TODO: Read chartVersion from Chart.yaml
+                    def chartVersion = '1.0.0'
+                    withCredentials([string(credentialsId: 'docker_hub_access_token', variable: 'DOCKER_HUB_ACCESS_TOKEN')]) {
+				        sh "docker login --username frooodle --password $DOCKER_HUB_ACCESS_TOKEN"
+				        sh "helm package chart/stirling-pdf"
+                        sh "helm push stirling-pdf-chart-1.0.0.tgz oci://registry-1.docker.io/frooodle"
+                    }
+                }
+            }
+        }
+    }
 }

--- a/chart/stirling-pdf/Chart.yaml
+++ b/chart/stirling-pdf/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
 maintainers:
 - name: Frooodle
   url: https://github.com/Frooodle/Stirling-PDF
-name: stirling-pdf
+name: stirling-pdf-chart
 sources:
 - https://github.com/Frooodle/Stirling-PDF
 version: 1.0.0


### PR DESCRIPTION
 #373 added the helm chart. With this PR I add the ability to automatically package and push the helm chart.

**Why is this necesarry?** 
Without this a user who wants to install stirling pdf using helm needs to checkout the repository and run `helm install ./chart ...` inside the repo. When the chart is published you can simply run `helm install oci://registry-1.docker.io/frooodle ...` without needing to checkout the repo first.

**What is OCI**
OCI is a new format that helm uses to package charts that can be stored in a docker image registry. So we can publish the chart alongside the docker images in the same registry, therefore the charts name can't be the same as the docker image and I renamed it to `stirling-pdf-chart`

** Disclaimer **
Since I don't have access to the Jenkins Server I cant test. I have manually published the chart to my accounts Github Package Registry using the following command, but since I only use ghcr.io instead of DockerHub I'm not 100% sure that the commands will work the same with docker. Please let me know if you need more help. 

```
helm package chart/stirling-pdf
helm push stirling-pdf-chart-1.0.0.tgz oci://ghcr.io/danielr1996
```

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
