### PR TITLE
Add container_name and healthcheck to docker_compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ services:
 #      - /location/of/customFiles:/customFiles/
     environment:
       - DOCKER_ENABLE_SECURITY=false
+    healthcheck: # optional: remember to adapt the host:port to your environment
+        test: ["CMD-SHELL", "/bin/bash set -o pipefail; curl --insecure --silent -m 2 https://localhost:443/ | grep 'Your locally hosted one-stop-shop for all your PDF needs.' || exit 1"]
+        interval: 60s
+        timeout: 10s
+        retries: 3
+        start_period: 40s
 ```
 
 Note: Podman is CLI-compatible with Docker, so simply replace "docker" with "podman".

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ version: '3.3'
 services:
   stirling-pdf:
     image: frooodle/s-pdf:latest
+    container_name: stirling-pdf
     ports:
       - '8080:8080'
     volumes:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ services:
     environment:
       - DOCKER_ENABLE_SECURITY=false
     healthcheck: # optional: remember to adapt the host:port to your environment
-        test: ["CMD-SHELL", "/bin/bash set -o pipefail; curl --insecure --silent -m 2 https://localhost:443/ | grep 'Your locally hosted one-stop-shop for all your PDF needs.' || exit 1"]
+        test: ["CMD-SHELL", "/bin/bash set -o pipefail; curl --insecure --silent -m 2 http://localhost:8080/ | grep 'Your locally hosted one-stop-shop for all your PDF needs.' || exit 1"]
         interval: 60s
         timeout: 10s
         retries: 3


### PR DESCRIPTION
# Container Name
The docker run command gives the container name via `--name stirling-pdf` but this is missing in the docker_compose.yml

# Healthcheck
I added a basic healthcheck using bash and curl querying localhost:8080 (the default port) and simply greping for the Stirling-PDF slogan "Your locally hosted one-stop-shop for all your PDF needs.".
Added a command to remind users that they need to adjust this, if they change there port (or use HTTPS).

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
