### PR TITLE
fix: Copy scripts to lite and ultra-lite images

### DIFF
--- a/Dockerfile-lite
+++ b/Dockerfile-lite
@@ -30,12 +30,14 @@ RUN mkdir -p /scripts /usr/share/fonts/opentype/noto /configs /customFiles
 #    chown -R stirlingpdfuser:stirlingpdfgroup /usr/share/fonts/opentype/noto /configs /customFiles
 
 # Copy necessary files
+COPY ./scripts/* /scripts/
 COPY src/main/resources/static/fonts/*.ttf /usr/share/fonts/opentype/noto/
 COPY src/main/resources/static/fonts/*.otf /usr/share/fonts/opentype/noto/
 COPY build/libs/*.jar app.jar
 
 # Set font cache and permissions
 RUN fc-cache -f -v 
+RUN chmod +x /scripts/init.sh
 #    chown stirlingpdfuser:stirlingpdfgroup /app.jar
 
 

--- a/Dockerfile-ultra-lite
+++ b/Dockerfile-ultra-lite
@@ -20,9 +20,12 @@ ENV DOCKER_ENABLE_SECURITY=false \
 
 RUN mkdir -p /scripts /usr/share/fonts/opentype/noto /configs /customFiles
 
+# Copy necessary files
+COPY ./scripts/* /scripts/
 COPY build/libs/*.jar app.jar
 
 # Set font cache and permissions
+RUN chmod +x /scripts/init.sh
 #RUN chown stirlingpdfuser:stirlingpdfgroup /app.jar
 
 # Expose the application port


### PR DESCRIPTION
From 0.17.0, lite and ultra-lite images fail to start due to missing entrypoint script.

TODO:
- [x] Test images
  - [x] lite
   - Container starts successfully, no further tests done.
  - [ ] ultra-lite  
   - Fails to start. note: `/scripts/init.sh` has a bash shebang. alpine does not ship with bash ootb so fails to start.
    - possible fix: install bash during image build.
    - possible fix: change script to run with `/bin/sh`

fixes #531

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
