### PR TITLE
fix!: map BMP and TIFF extensions to the proper MIME types

### DIFF
--- a/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
+++ b/src/main/java/stirling/software/SPDF/controller/api/converters/ConvertImgPDFController.java
@@ -1,6 +1,7 @@
 package stirling.software.SPDF.controller.api.converters;
 
 import java.io.IOException;
+import java.net.URLConnection;
 
 import org.apache.pdfbox.rendering.ImageType;
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ import stirling.software.SPDF.model.api.converters.ConvertToImageRequest;
 import stirling.software.SPDF.model.api.converters.ConvertToPdfRequest;
 import stirling.software.SPDF.utils.PdfUtils;
 import stirling.software.SPDF.utils.WebResponseUtils;
+
 @RestController
 @RequestMapping("/api/v1/convert")
 @Tag(name = "Convert", description = "Convert APIs")
@@ -89,15 +91,7 @@ public class ConvertImgPDFController {
     }
 
     private String getMediaType(String imageFormat) {
-        if (imageFormat.equalsIgnoreCase("PNG"))
-            return "image/png";
-        else if (imageFormat.equalsIgnoreCase("JPEG") || imageFormat.equalsIgnoreCase("JPG"))
-            return "image/jpeg";
-        else if (imageFormat.equalsIgnoreCase("GIF"))
-            return "image/gif";
-        else
-            return "application/octet-stream";
+        String mimeType = URLConnection.guessContentTypeFromName("." + imageFormat);
+        return mimeType.equals("null") ? "application/octet-stream" : mimeType;
     }
-
-
 }

--- a/src/main/resources/templates/convert/pdf-to-img.html
+++ b/src/main/resources/templates/convert/pdf-to-img.html
@@ -26,7 +26,6 @@
                                     <option value="gif">GIF</option>
                                     <option value="tiff">TIFF</option>
                                     <option value="bmp">BMP</option>
-                                    <option value="wbmp">WBMP</option>
                                 </select>
                             </div>
                             <div class="mb-3">


### PR DESCRIPTION
# Description

This change fixes the issue where `BMP` and `TIFF` formats lack the content type header, resulting in a file download without an extension when using PDF to Image.

> [!WARNING]
> This change also removes the WBMP image format from PDF to Image.

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
