### PR TITLE
fix: sequentially convert each pdf page into a BufferedImage to avoid getting out of memory errors for large pdf files

### DIFF
--- a/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
+++ b/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
@@ -205,11 +205,6 @@ public class PdfUtils {
             int pageCount = document.getNumberOfPages();
             List<BufferedImage> images = new ArrayList<>();
 
-            // Create images of all pages
-            for (int i = 0; i < pageCount; i++) {
-                images.add(pdfRenderer.renderImageWithDPI(i, DPI, colorType));
-            }
-
             // Create a ByteArrayOutputStream to save the image(s) to
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
@@ -226,8 +221,8 @@ public class PdfUtils {
                         writer.setOutput(ios);
                         writer.prepareWriteSequence(null);
 
-                        for (int i = 0; i < images.size(); ++i) {
-                            BufferedImage image = images.get(i);
+                        for (int i = 0; i < pageCount; ++i) {
+                            BufferedImage image = pdfRenderer.renderImageWithDPI(i, DPI, colorType);
                             writer.writeToSequence(new IIOImage(image, null, null), param);
                         }
 
@@ -240,8 +235,9 @@ public class PdfUtils {
                     BufferedImage combined = new BufferedImage(images.get(0).getWidth(), images.get(0).getHeight() * pageCount, BufferedImage.TYPE_INT_RGB);
                     Graphics g = combined.getGraphics();
 
-                    for (int i = 0; i < images.size(); i++) {
-                        g.drawImage(images.get(i), 0, i * images.get(0).getHeight(), null);
+                    for (int i = 0; i < pageCount; ++i) {
+                        BufferedImage image = pdfRenderer.renderImageWithDPI(i, DPI, colorType);
+                        g.drawImage(image, 0, i * image.getHeight(), null);
                     }
 
                     // Write the image to the output stream
@@ -253,8 +249,8 @@ public class PdfUtils {
             } else {
                 // Zip the images and return as byte array
                 try (ZipOutputStream zos = new ZipOutputStream(baos)) {
-                    for (int i = 0; i < images.size(); i++) {
-                        BufferedImage image = images.get(i);
+                    for (int i = 0; i < pageCount; ++i) {
+                        BufferedImage image = pdfRenderer.renderImageWithDPI(i, DPI, colorType);
                         try (ByteArrayOutputStream baosImage = new ByteArrayOutputStream()) {
                             ImageIO.write(image, imageType, baosImage);
 

--- a/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
+++ b/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
@@ -236,7 +236,9 @@ public class PdfUtils {
                     Graphics g = combined.getGraphics();
 
                     for (int i = 0; i < pageCount; ++i) {
-                        BufferedImage image = pdfRenderer.renderImageWithDPI(i, DPI, colorType);
+                        if (i != 0) {
+                            image = pdfRenderer.renderImageWithDPI(i, DPI, colorType);
+			}
                         g.drawImage(image, 0, i * image.getHeight(), null);
                     }
 

--- a/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
+++ b/src/main/java/stirling/software/SPDF/utils/PdfUtils.java
@@ -203,7 +203,6 @@ public class PdfUtils {
         try (PDDocument document = PDDocument.load(new ByteArrayInputStream(inputStream))) {
             PDFRenderer pdfRenderer = new PDFRenderer(document);
             int pageCount = document.getNumberOfPages();
-            List<BufferedImage> images = new ArrayList<>();
 
             // Create a ByteArrayOutputStream to save the image(s) to
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -232,7 +231,8 @@ public class PdfUtils {
                     writer.dispose();
                 } else {
                     // Combine all images into a single big image
-                    BufferedImage combined = new BufferedImage(images.get(0).getWidth(), images.get(0).getHeight() * pageCount, BufferedImage.TYPE_INT_RGB);
+                    BufferedImage image = pdfRenderer.renderImageWithDPI(0, DPI, colorType);
+                    BufferedImage combined = new BufferedImage(image.getWidth(), image.getHeight() * pageCount, BufferedImage.TYPE_INT_RGB);
                     Graphics g = combined.getGraphics();
 
                     for (int i = 0; i < pageCount; ++i) {


### PR DESCRIPTION
# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
