### PR TITLE
Set java file.encoding to support non-latin customizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ EXPOSE 8080
 # Set user and run command
 ##USER stirlingpdfuser
 ENTRYPOINT ["/scripts/init.sh"]
-CMD ["java", "-jar", "/app.jar"]
+CMD ["java", "-Dfile.encoding=UTF-8", "-jar", "/app.jar"]

--- a/Dockerfile-lite
+++ b/Dockerfile-lite
@@ -60,4 +60,4 @@ ENV DOCKER_ENABLE_SECURITY=false
 # Run the application
 #USER stirlingpdfuser
 ENTRYPOINT ["/scripts/init-without-ocr.sh"]
-CMD ["java", "-jar", "/app.jar"]
+CMD ["java", "-Dfile.encoding=UTF-8", "-jar", "/app.jar"]

--- a/Dockerfile-ultra-lite
+++ b/Dockerfile-ultra-lite
@@ -42,4 +42,4 @@ ENV ENDPOINTS_GROUPS_TO_REMOVE=CLI
 ENTRYPOINT ["/scripts/init-without-ocr.sh"]
 
 # Run the application
-CMD ["java", "-jar", "/app.jar"]
+CMD ["java", "-Dfile.encoding=UTF-8", "-jar", "/app.jar"]


### PR DESCRIPTION
E.g. non-latin customizations via UI_APPNAME, UI_HOMEDESCRIPTION, etc looks like this without this option:

![image](https://github.com/Frooodle/Stirling-PDF/assets/50209/bcac80af-e35f-480e-8dfe-9274417f409b)

# License Agreement for Contributions
By submitting this pull request, I acknowledge and agree that my contributions will be included in Stirling-PDF and that they can be relicensed in the future under MPL 2.0 (Mozilla Public License Version 2.0) license. 

(This does not change the general open-source nature of Stirling-PDF, simply moving from one license to another license)
